### PR TITLE
Add minimal Kotlin Spring JPA example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.gradle
+/build
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Spring JPA Example
+
+This is a minimal Kotlin + Spring Boot project demonstrating how to map two entities, `Author` and `Book`, using JPA/Hibernate.
+
+## Building
+
+Run the following command to build the project:
+
+```bash
+./gradlew build
+```
+
+The build uses an in-memory H2 database and creates the schema automatically at startup.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("org.springframework.boot") version "3.2.5"
+    id("io.spring.dependency-management") version "1.1.4"
+    kotlin("jvm") version "1.9.24"
+    kotlin("plugin.spring") version "1.9.24"
+    kotlin("plugin.jpa") version "1.9.24"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_21
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    runtimeOnly("com.h2database:h2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "spring-jpa-example"

--- a/src/main/kotlin/com/example/demo/Author.kt
+++ b/src/main/kotlin/com/example/demo/Author.kt
@@ -1,0 +1,13 @@
+package com.example.demo
+
+import jakarta.persistence.*
+
+@Entity
+class Author(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val name: String
+) {
+    @OneToMany(mappedBy = "author", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val books: MutableList<Book> = mutableListOf()
+}

--- a/src/main/kotlin/com/example/demo/AuthorRepository.kt
+++ b/src/main/kotlin/com/example/demo/AuthorRepository.kt
@@ -1,0 +1,5 @@
+package com.example.demo
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AuthorRepository : JpaRepository<Author, Long>

--- a/src/main/kotlin/com/example/demo/Book.kt
+++ b/src/main/kotlin/com/example/demo/Book.kt
@@ -1,0 +1,14 @@
+package com.example.demo
+
+import jakarta.persistence.*
+
+@Entity
+class Book(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    val title: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    val author: Author
+)

--- a/src/main/kotlin/com/example/demo/BookRepository.kt
+++ b/src/main/kotlin/com/example/demo/BookRepository.kt
@@ -1,0 +1,5 @@
+package com.example.demo
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BookRepository : JpaRepository<Book, Long>

--- a/src/main/kotlin/com/example/demo/DemoApplication.kt
+++ b/src/main/kotlin/com/example/demo/DemoApplication.kt
@@ -1,0 +1,11 @@
+package com.example.demo
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class DemoApplication
+
+fun main(args: Array<String>) {
+    runApplication<DemoApplication>(*args)
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.h2.console.enabled=true

--- a/src/test/kotlin/com/example/demo/DemoApplicationTests.kt
+++ b/src/test/kotlin/com/example/demo/DemoApplicationTests.kt
@@ -1,0 +1,10 @@
+package com.example.demo
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class DemoApplicationTests {
+    @Test
+    fun contextLoads() {}
+}


### PR DESCRIPTION
## Summary
- set up Gradle Kotlin project with Spring Boot and JPA
- define `Author` and `Book` JPA entities
- add repositories and application entrypoint
- include an example test and configuration

## Testing
- `gradle test` *(fails: Plugin 'org.springframework.boot' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447a39598c832e977256686c4d02bb